### PR TITLE
feat: add scout extended configuration

### DIFF
--- a/config/repositories.php
+++ b/config/repositories.php
@@ -74,4 +74,10 @@ return [
             'maxQueriesPerIPPerHour' => 10000,
         ],
     ],
+    'algolia/scout-extended' => [
+        'app-id' => 'I2UB5B7IZB',
+        'key-params' => [
+            'maxQueriesPerIPPerHour' => 10000,
+        ],
+    ],
 ];


### PR DESCRIPTION
This adds the configuration for [`algolia/scout-extended`](https://github.com/algolia/scout-extended). I didn't add an `indexes` key to the `key-params`, because the index name differs per model.